### PR TITLE
Fix/provider icon name mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ device. The main purpose is to view the Signal Strength (dBm) for both Cellular 
 graph.
 
 ## Screenshots
+
 <p>
   <img src="images/Screenshot_Welcomepage.jpg" width="250" />
   <img src="images/Screenshot_Mainpage.jpg" width="250" />
@@ -20,6 +21,7 @@ graph.
 </p>
 
 ## Built With
+
 Native Android development with Kotlin and XML
 
 **Used Libraries**
@@ -27,19 +29,25 @@ Native Android development with Kotlin and XML
 * [better-gauge-android](https://github.com/Magnus987/better-gauge-android/tree/Signalo)
 * [Material Components](https://github.com/material-components)
 * [timber](https://github.com/JakeWharton/timber)
+
 ## Set up
 
 1. Clone the repository:
+
 ```bash
     git clone https://github.com/it-at-m/signalo.git
 ```
 
-2. Clone the required [gauge library](https://github.com/Magnus987/better-gauge-android/tree/Signalo) and copy the "gaugelibrary" folder into your root project structure.
+2. Clone the
+   required [gauge library](https://github.com/Magnus987/better-gauge-android/tree/Signalo) and copy
+   the "gaugelibrary" folder into your root project structure.
 
 3. If you like, change the App ID in `build.gradle.kts` to your own.
 
 4. Open the project in your preferred IDE, sync Gradle, and build.
+
 ## Documentation
+
 The main purpose is to view the Signal Strength (dBm) for both Cellular and Wifi in a gauge
 graph. But also some extra stats are displayed:
 
@@ -65,10 +73,9 @@ graph. But also some extra stats are displayed:
 * Dual-SIM Support
     * When the app detects 2 usable SIM cards, it switches the view to not only display a button for
       Cellular but for SIM1 and SIM2, so the user can choose which SIM to use and compare.
-* Single-SIM Detection
+* None-SIM Detection
     * When the app finds no usable SIM cards, it automatically switches the view to Wifi and
       disables the Cellular page.
-
 
 **Technical details**
 
@@ -88,21 +95,27 @@ graph. But also some extra stats are displayed:
 * **Cellular**
     * All cellular data is requested via the TelephonyManager registered on the selected SIM.
         * Internet Provider
-            * Name and logo of the internet provider from your connected cell tower. So if you have a
+            * Name and logo of the internet provider from your connected cell tower. So if you have
+              a
               SIM from Telekom but it connects you to an A1 cell tower, the app shows A1.
         * Network Type
-            * Name and logo of the used cellular technology. If it differs from your system's display,
-              it's probably because of marketing ;) Android shows that you are connected via 5G but in
-              reality it's 5G NSA (Non Standalone) which means your device uses 5G for data but still
+            * Name and logo of the used cellular technology. If it differs from your system's
+              display,
+              it's probably because of marketing ;) Android shows that you are connected via 5G but
+              in
+              reality it's 5G NSA (Non Standalone) which means your device uses 5G for data but
+              still
               relies on a 4G/LTE anchor for connection management – true standalone 5G (SA) operates
               entirely on 5G infrastructure.
         * Frequency Band
-            * Frequency bands are displayed with their standard 3GPP prefix: B for LTE bands and n for
+            * Frequency bands are displayed with their standard 3GPP prefix: B for LTE bands and n
+              for
               5G NR bands.
             * Access fine location permission is needed to display this value.
             * Read Phone state permission is needed to display this value.
         * Cell ID (ECI)
-            * The ECI (E-UTRAN Cell Identifier) uniquely identifies the cell you're connected to. It's
+            * The ECI (E-UTRAN Cell Identifier) uniquely identifies the cell you're connected to.
+              It's
               unique within your country and your provider.
             * Access fine location permission is needed to display this value.
             * Read Phone state permission is needed to display this value.
@@ -120,12 +133,14 @@ graph. But also some extra stats are displayed:
         * Linkspeed
             * The link speed of the connected Wifi is displayed in Megabits per second.
 
-
 ## Contributing
 
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+Contributions are what make the open source community such an amazing place to learn, inspire, and
+create. Any contributions you make are **greatly appreciated**.
 
-If you have a suggestion that would make this better, please open an issue with the tag "enhancement", fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
+If you have a suggestion that would make this better, please open an issue with the tag "
+enhancement", fork the repo and create a pull request. You can also simply open an issue with the
+tag "enhancement".
 Don't forget to give the project a star! Thanks again!
 
 1. Open an issue with the tag "enhancement"
@@ -137,16 +152,16 @@ Don't forget to give the project a star! Thanks again!
 
 More about this in the [CODE_OF_CONDUCT](/CODE_OF_CONDUCT.md) file.
 
-
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) file for more information.
-
 
 ## Contact
 
 it@M - opensource@muenchen.de
 
 <!-- project shields / links -->
+
 [made-with-love-shield]: https://img.shields.io/badge/made%20with%20%E2%9D%A4%20by-it%40M-yellow?style=for-the-badge
+
 [itm-opensource]: https://opensource.muenchen.de/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.example.test.signalo"
         minSdk = 35
         targetSdk = 35
-        versionCode = 9
-        versionName = "0.3.2"
+        versionCode = 10
+        versionName = "0.3.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/de/muenchen/appcenter/signalo/MainFragment.kt
+++ b/app/src/main/java/de/muenchen/appcenter/signalo/MainFragment.kt
@@ -644,18 +644,66 @@ class MainFragment : Fragment() {
     }
 
     /**
-     * fetch networkOperator from telephonymanager
-     * this is the mnc+mcc value delivered by the current connected celltower
-     * call setProviderIcons with this param
-     * if networkOperator is empty, call setProviderIcons with 0 to set a fallback ? icon
+     * calls setProviderIcons to demeter the provider name based on the selected logo (which is based on the MNC and MCC code)
+     * if no logo was selected call fallback function fetchCellularProviderNameFallback
      */
-    private fun fetchCellularProviderCode() {
+    private fun fetchCellularProviderName() {
+        var selectedIcon = 0
         if (!telephonyManager.networkOperator.isNullOrBlank()) {
-            val currentProviderCode = telephonyManager.networkOperator.toInt()
-            setProviderIcons(currentProviderCode)
+            selectedIcon = setProviderIcons(telephonyManager.networkOperator.toInt()) ?: 0
+        }
+        when (selectedIcon) {
+            R.drawable.deutsche_telekom_2022_svg -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_TELEKOM)
+            }
+
+            R.drawable.vodafone_kabel_deutschland_logo_vector -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_VODAFONE)
+            }
+
+            R.drawable.o2_svg -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_O2)
+            }
+
+            R.drawable.__1_logo -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_1UND1)
+            }
+
+            R.drawable.logo_of_a1 -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_A1)
+            }
+
+            R.drawable.scmn_sw_38a30a24 -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_SWISSCOM)
+            }
+
+            R.drawable.sunrise_2022_svg -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_SUNRISE)
+            }
+
+            R.drawable.icones_logosalt_black -> {
+                viewmodel.setcurrentNetProvider(Constants.PROVIDER_SALT)
+            }
+
+            else -> {
+                Timber.d("MCC/MNC could not be mapped to a known provider, calling fallback function...")
+                fetchCellularProviderNameFallback()
+            }
+        }
+    }
+
+    /**
+     * fetches OperatorName from telephony manager and Sets in UI
+     * if it is Null or Blank, set "Unknown Provider" in UI
+     */
+    private fun fetchCellularProviderNameFallback() {
+        val currentProviderName = telephonyManager.networkOperatorName
+        Timber.d("NetworkOperatorname: " + currentProviderName)
+        if (!currentProviderName.isNullOrBlank()) {
+            viewmodel.setcurrentNetProvider(currentProviderName)
         } else {
-            Timber.d("Cellular Provider Code is null or Empty, using ? Icon")
-            setProviderIcons(0)
+            Timber.d("Cellular Provider/Operator fallback Name is null or Blank, setting UI value to 'Unknown Provider'")
+            viewmodel.setcurrentNetProvider("Unknown Provider")
         }
     }
 
@@ -707,71 +755,6 @@ class MainFragment : Fragment() {
         }
         return providerIcons[currentProviderCode]
     }
-
-    /**
-     * fetches OperatorName from telephony manager and Sets in UI
-     * if its null or empty call a fallback fun
-     */
-    private fun fetchCellularProviderNameFallback() {
-        val currentProviderName = telephonyManager.networkOperatorName
-        Timber.d("NetworkOperatorname: " + currentProviderName)
-        if (!currentProviderName.isNullOrBlank()) {
-            viewmodel.setcurrentNetProvider(currentProviderName)
-        } else {
-            Timber.d("Cellular Provider/Operator fallback Name is null or Blank, setting UI value to 'Unknown Provider'")
-            viewmodel.setcurrentNetProvider("Unknown Provider")
-        }
-    }
-
-    /**
-     * calls setProviderIcons to demeter the provider name based on the selected logo (which is based on the MNC and MCC code)
-     * if no logo was selected use fallback value "unknown Provider"
-     */
-    private fun fetchCellularProviderName() {
-        var selectedIcon = 0
-        if (!telephonyManager.networkOperator.isNullOrBlank()) {
-            selectedIcon = setProviderIcons(telephonyManager.networkOperator.toInt()) ?: 0
-        }
-        when (selectedIcon) {
-            R.drawable.deutsche_telekom_2022_svg -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_TELEKOM)
-            }
-
-            R.drawable.vodafone_kabel_deutschland_logo_vector -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_VODAFONE)
-            }
-
-            R.drawable.o2_svg -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_O2)
-            }
-
-            R.drawable.__1_logo -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_1UND1)
-            }
-
-            R.drawable.logo_of_a1 -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_A1)
-            }
-
-            R.drawable.scmn_sw_38a30a24 -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_SWISSCOM)
-            }
-
-            R.drawable.sunrise_2022_svg -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_SUNRISE)
-            }
-
-            R.drawable.icones_logosalt_black -> {
-                viewmodel.setcurrentNetProvider(Constants.PROVIDER_SALT)
-            }
-
-            else -> {
-                Timber.d("MCC/MNC could not be mapped to a known provider, calling fallback function...")
-                fetchCellularProviderNameFallback()
-            }
-        }
-    }
-
 
     /**
      * a function to combine all cellular data gatherings except for the dbm value

--- a/app/src/main/java/de/muenchen/appcenter/signalo/MainFragment.kt
+++ b/app/src/main/java/de/muenchen/appcenter/signalo/MainFragment.kt
@@ -23,7 +23,6 @@ import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.UserManager
 import android.telephony.CellIdentityNr
 import android.telephony.CellInfo
 import android.telephony.CellInfoGsm
@@ -54,12 +53,13 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResultListener
 import androidx.transition.TransitionManager
 import com.ekn.gruzer.gaugelibrary.Range
-import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.transition.MaterialSharedAxis
 import com.example.test.signalo.databinding.FragmentMainBinding
 import com.example.test.signalo.utils.Constants
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.transition.MaterialSharedAxis
 import kotlinx.coroutines.Job
 import timber.log.Timber
+
 /**
  * This class handles most of the logic of the mainpage, fetching Networkstats, changing UI stuff...
  */
@@ -144,7 +144,7 @@ class MainFragment : Fragment() {
 
     /**starts a manual wifi scan to receive newest wifi DBM values
      * registers a broadcast receiver to look for scans from Android system but only if SCAN_PENDING
-     * catches the resultlist and extract the dbm value for the Network with the current connected BSSID
+     * catches the result list and extract the dbm value for the Network with the current connected BSSID
      *
      */
     private fun manualWifiRefresh() {
@@ -332,8 +332,8 @@ class MainFragment : Fragment() {
 
     //only check if  permissions are present,if not present open up WelcomeDialog to ask the user again once in a session
     private fun checkPermissions() {
-        if ((!hasSinglePermission(ACCESS_FINE_LOCATION) || !hasSinglePermission(READ_PHONE_STATE)) && viewmodel.permissionRequestedThisSession.value!=true) {
-            viewmodel.permissionRequestedThisSession.value= true
+        if ((!hasSinglePermission(ACCESS_FINE_LOCATION) || !hasSinglePermission(READ_PHONE_STATE)) && viewmodel.permissionRequestedThisSession.value != true) {
+            viewmodel.permissionRequestedThisSession.value = true
             startWelcomeDialog(force = true)
         }
     }
@@ -709,17 +709,17 @@ class MainFragment : Fragment() {
     }
 
     /**
-     * fetches OperatorName from telephonymanager and Sets in UI
+     * fetches OperatorName from telephony manager and Sets in UI
      * if its null or empty call a fallback fun
      */
-    private fun fetchCellularProviderName() {
+    private fun fetchCellularProviderNameFallback() {
         val currentProviderName = telephonyManager.networkOperatorName
         Timber.d("NetworkOperatorname: " + currentProviderName)
         if (!currentProviderName.isNullOrBlank()) {
             viewmodel.setcurrentNetProvider(currentProviderName)
         } else {
-            Timber.d("Cellular Provider/Operator Name is null or Blank, using fallback fun")
-            fetchFallbackCellularProvidername()
+            Timber.d("Cellular Provider/Operator fallback Name is null or Blank, setting UI value to 'Unknown Provider'")
+            viewmodel.setcurrentNetProvider("Unknown Provider")
         }
     }
 
@@ -727,7 +727,7 @@ class MainFragment : Fragment() {
      * calls setProviderIcons to demeter the provider name based on the selected logo (which is based on the MNC and MCC code)
      * if no logo was selected use fallback value "unknown Provider"
      */
-    private fun fetchFallbackCellularProvidername() {
+    private fun fetchCellularProviderName() {
         var selectedIcon = 0
         if (!telephonyManager.networkOperator.isNullOrBlank()) {
             selectedIcon = setProviderIcons(telephonyManager.networkOperator.toInt()) ?: 0
@@ -766,7 +766,8 @@ class MainFragment : Fragment() {
             }
 
             else -> {
-                viewmodel.setcurrentNetProvider("Unknown Provider")
+                Timber.d("MCC/MNC could not be mapped to a known provider, calling fallback function...")
+                fetchCellularProviderNameFallback()
             }
         }
     }
@@ -774,7 +775,7 @@ class MainFragment : Fragment() {
 
     /**
      * a function to combine all cellular data gatherings except for the dbm value
-     * registeres a onCapChanged callback for functions who dont have an own callback, so they are getting refreshed when anything network related changes
+     * registers a onCapChanged callback for functions who don't have an own callback, so they are getting refreshed when anything network related changes
      */
     private fun fetchAllCellularData() {
         Timber.d("getAllCellularData is called")
@@ -787,7 +788,6 @@ class MainFragment : Fragment() {
                     networkCapabilities: NetworkCapabilities
                 ) {
                     super.onCapabilitiesChanged(network, networkCapabilities)
-                    fetchCellularProviderCode()
                     fetchCellularProviderName()
                     readCellIdAndBandFromTelephonyManagerAndSetInUi()
                 }
@@ -904,7 +904,7 @@ class MainFragment : Fragment() {
 
     /**
      * fetch current EncryptionType and display in UI
-     * @param wifiInfo the object received by wifimanager(networkCapabilities.transportInfo)
+     * @param wifiInfo the object received by wifi manager(networkCapabilities.transportInfo)
      */
     private fun fetchEncryptionType(wifiInfo: WifiInfo) {
         val encryptionType = when (wifiInfo.currentSecurityType) {

--- a/app/src/main/java/de/muenchen/appcenter/signalo/MainFragment.kt
+++ b/app/src/main/java/de/muenchen/appcenter/signalo/MainFragment.kt
@@ -703,7 +703,7 @@ class MainFragment : Fragment() {
             viewmodel.setcurrentNetProvider(currentProviderName)
         } else {
             Timber.d("Cellular Provider/Operator fallback Name is null or Blank, setting UI value to 'Unknown Provider'")
-            viewmodel.setcurrentNetProvider("Unknown Provider")
+            viewmodel.setcurrentNetProvider(getString(R.string.unknown_provider))
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="card_value4">%s</string>
 
     <!--Cellular Descriptions-->
-    <string name="card_description1">Internet Provider</string>
+    <string name="card_description1">Netzbetreiber</string>
     <string name="card_description3">Frequenzband</string>
     <string name="card_description2">Funkstandard</string>
     <string name="card_description4">Cell ID (ECI)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="app_icon_desc">App Icon</string>
     <string name="app_logo_content_desc">App_Logo</string>
     <string name="optional">Optional</string>
+    <string name="unknown_provider">Unknown Provider</string>
 
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,39 @@
+[versions]
+agp = "8.9.2"
+kotlin = "2.0.21"
+coreKtx = "1.10.1"
+junit = "4.13.2"
+junitVersion = "1.1.5"
+espressoCore = "3.5.1"
+appcompat = "1.6.1"
+material = "1.10.0"
+constraintlayout = "2.1.4"
+materialVersion = "1.13.0"
+navigationFragmentKtx = "2.6.0"
+navigationFragmentKtxVersion = "2.8.5"
+navigationUiKtx = "2.6.0"
+navigationUiKtxVersion = "2.8.5"
+swiperefreshlayout = "1.2.0-rc01"
+timber = "5.0.1"
+workRuntimeKtx = "2.10.4"
+
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-navigation-fragment-ktx-v285 = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtxVersion" }
+androidx-navigation-ui-ktx-v285 = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationUiKtxVersion" }
+androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
+androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
+material-v1130 = { module = "com.google.android.material:material", version.ref = "materialVersion" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
**Description**
Fixed provider icon and name showing different providers. Both are now consistently derived from the MCC/MNC code, resolving mismatches for MVNO SIMs (e.g. WEtell, congstar, ...). 
Renamed the UI label from "Internet Provider" to "Netzbetreiber".
Behavior now matches the README description.
Added libs.versions.toml file to make fresh pull and build possible.  
Cleaned up old code. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved provider detection with logo mapping and a fallback that displays a derived or "Unknown Provider" name.

* **Documentation**
  * README text and formatting refinements.
  * Updated UI label from "Internet Provider" to localized "Netzbetreiber" and added "Unknown Provider" string.

* **Chores**
  * App version bumped to 0.3.3 (versionCode incremented).
  * Added centralized dependency version catalog for build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->