### PR TITLE
chore: add privacy policy to prepare playstore release

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Signalo Overview</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 900px;
+            margin: auto;
+            padding: 40px;
+            line-height: 1.7;
+            color: #333;
+        }
+        h1 {
+            border-bottom: 2px solid #ddd;
+            padding-bottom: 10px;
+        }
+        h2 {
+            margin-top: 40px;
+        }
+        .lang {
+            margin-top: 70px;
+            padding-top: 40px;
+            border-top: 2px solid #ddd;
+        }
+        .footer {
+            margin-top: 80px;
+            font-size: 14px;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+<h1>Welcome to Signalo</h1>
+<p>
+    Signalo is a native Android app which enables users to monitor live network stats of their
+    device. The main purpose is to view the Signal Strength (dBm) for both Cellular and Wifi in a
+    gauge graph.
+</p>
+
+<h2>Features</h2>
+<ul>
+    <li>Live signal strength visualization (dBm) via an intuitive gauge graph with color-coded
+        thresholds
+    </li>
+    <li>Detailed cellular stats: Network Provider, Network Type, Frequency Band, Cell ID (ECI)</li>
+    <li>Detailed Wifi stats: SSID, Frequency Band, Encryption, Linkspeed</li>
+    <li>Dual-SIM support with per-SIM signal comparison</li>
+    <li>Manual Wifi refresh for the newest and most precise signal values</li>
+    <li>Automatic no-SIM detection with fallback to Wifi page</li>
+</ul>
+
+<h2>Privacy</h2>
+<p>Please refer to our <a href="privacy.html">Privacy Policy</a> for details on how Signalo handles
+    your data.</p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Signalo Overview</title>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Signalo Privacy Policy</title>
+
+    <style>
+
+        body{
+        font-family: Arial, sans-serif;
+        max-width: 900px;
+        margin: auto;
+        padding: 40px;
+        line-height: 1.7;
+        color:#333;
+        }
+
+        h1{
+        border-bottom:2px solid #ddd;
+        padding-bottom:10px;
+        }
+
+        h2{
+        margin-top:40px;
+        }
+
+        .footer{
+        margin-top:80px;
+        font-size:14px;
+        color:#777;
+        }
+
+    </style>
+</head>
+
+<body>
+
+<h1>Signalo Privacy Policy</h1>
+
+<p><strong>Last updated</strong> 24.03.2026</p>
+
+<h2>1. Data Controller</h2>
+
+<p>
+    The controller responsible for data processing related to the Signalo application is:
+</p>
+
+<p>
+    Landeshauptstadt München - IT-Referat - it@M - Mobile Services<br>
+    Agnes-Pockels-Bogen 33, 80992 München<br>
+    E-Mail: apps@muenchen.de
+</p>
+
+<h2>2. Description of the Application</h2>
+
+<p>
+    Signalo is a native Android application which enables users to monitor live network stats of
+    their
+    device. The main purpose is to view the Signal Strength (dBm) for both Cellular and Wifi in a
+    gauge graph.
+    Signalo does not communicate with any server, device or third party. None of the data requested
+    from Android
+    is stored or shared - it is only used to display live network information within the
+    application.
+    This privacy policy is necessary for the published version of Signalo in the Google Play Store.
+</p>
+
+<h2>3. Legal Basis</h2>
+
+<p>
+    Data processing is based on Article 6(1)(f) GDPR (legitimate interests).
+</p>
+
+<p>
+    The legitimate interest consists of:
+</p>
+
+<ul>
+    <li>providing network monitoring functionality</li>
+    <li>displaying signal strength and connection details</li>
+</ul>
+
+<h2>4. Data Sharing</h2>
+
+<p>
+    Signalo does not store, process, or share any personal data. All network information displayed
+    in the app is read locally on the device and is not transmitted to any server or third party.
+</p>
+
+<h2>6. User Rights (GDPR)</h2>
+
+<p>
+    Users have the following rights:
+</p>
+
+<ul>
+    <li>Right of access (Art. 15 GDPR)</li>
+    <li>Right to rectification (Art. 16 GDPR)</li>
+    <li>Right to erasure (Art. 17 GDPR)</li>
+    <li>Right to restriction of processing (Art. 18 GDPR)</li>
+    <li>Right to data portability (Art. 20 GDPR)</li>
+    <li>Right to object (Art. 21 GDPR)</li>
+</ul>
+
+<p>
+    Requests can be sent to the contact address listed above.
+</p>
+
+<h2>7. Changes to this Policy</h2>
+
+<p>
+    This privacy policy may be updated from time to time.
+</p>
+
+<p>
+    The latest version will always be available on this page.
+</p>
+
+<div class="footer">
+    Signalo Privacy Policy
+</div>
+
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Signalo Privacy Policy</title>
@@ -87,7 +87,7 @@
     in the app is read locally on the device and is not transmitted to any server or third party.
 </p>
 
-<h2>6. User Rights (GDPR)</h2>
+<h2>5. User Rights (GDPR)</h2>
 
 <p>
     Users have the following rights:
@@ -106,7 +106,7 @@
     Requests can be sent to the contact address listed above.
 </p>
 
-<h2>7. Changes to this Policy</h2>
+<h2>6. Changes to this Policy</h2>
 
 <p>
     This privacy policy may be updated from time to time.


### PR DESCRIPTION
**Description**

add privacy policy to prepare Playstore release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an application overview page describing Signalo as a native Android app for live network statistics, including cellular and Wi‑Fi detail monitoring, dual‑SIM comparison, manual Wi‑Fi refresh, and no‑SIM detection.
  * Added a privacy policy page (last updated 24.03.2026) confirming local‑only monitoring, no external communication or data storage, and outlining GDPR user rights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->