### PR TITLE
feat: add external Speedtest Link to navDrawer, open in default browser

### DIFF
--- a/app/src/main/java/de/muenchen/appcenter/signalo/MainActivity.kt
+++ b/app/src/main/java/de/muenchen/appcenter/signalo/MainActivity.kt
@@ -1,5 +1,6 @@
 package de.muenchen.appcenter.signalo
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
@@ -12,15 +13,18 @@ import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.navigation.NavigationView
+import com.google.android.material.snackbar.Snackbar
 import de.muenchen.appcenter.signalo.databinding.ActivityMainBinding
 import de.muenchen.appcenter.signalo.utils.Constants
 import timber.log.Timber
@@ -144,10 +148,55 @@ class MainActivity : AppCompatActivity() {
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
+        navView.setNavigationItemSelectedListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.externalSpeedtest -> {
+                    drawerLayout.closeDrawer(GravityCompat.START)
+                    showExternalSpeedtestDialog()
+                    false
+                }
+
+                else -> {
+                    NavigationUI.onNavDestinationSelected(menuItem, navController)
+                    drawerLayout.closeDrawer(GravityCompat.START)
+                    true
+                }
+            }
+        }
         navController.addOnDestinationChangedListener { _, destination, _ ->
             currentFragmentId = destination.id
             invalidateOptionsMenu()
 
+        }
+    }
+
+    private fun showExternalSpeedtestDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.speedtest_dialog_title))
+            .setMessage(getString(R.string.speedtest_dialog_message))
+            .setPositiveButton(getString(R.string.speedtest_dialog_positive_button)) { dialog, _ ->
+                openSpeedtestBrowser()
+                dialog.dismiss()
+            }
+            .setNegativeButton(getString(R.string.speedtest_dialog_negative_button)) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
+    }
+
+    private fun openSpeedtestBrowser() {
+        val urlIntent = Intent(
+            Intent.ACTION_VIEW,
+            (getString(R.string.speedtest_URL)).toUri()
+        )
+        try {
+            startActivity(urlIntent)
+        } catch (e: ActivityNotFoundException) {
+            Snackbar.make(
+                this.findViewById(android.R.id.content),
+                getString(R.string.Speedtest_open_erorr),
+                Snackbar.LENGTH_SHORT
+            ).show()
         }
     }
 

--- a/app/src/main/res/drawable/open_in_new_24px.xml
+++ b/app/src/main/res/drawable/open_in_new_24px.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M200,840Q167,840 143.5,816.5Q120,793 120,760L120,200Q120,167 143.5,143.5Q167,120 200,120L480,120L480,200L200,200Q200,200 200,200Q200,200 200,200L200,760Q200,760 200,760Q200,760 200,760L760,760Q760,760 760,760Q760,760 760,760L760,480L840,480L840,760Q840,793 816.5,816.5Q793,840 760,840L200,840ZM388,628L332,572L704,200L560,200L560,120L840,120L840,400L760,400L760,256L388,628Z"/>
+</vector>

--- a/app/src/main/res/menu/nav_drawer.xml
+++ b/app/src/main/res/menu/nav_drawer.xml
@@ -15,7 +15,7 @@
     </group>
     <item
         android:id="@+id/externalSpeedtest"
-        android:title="Externer Speedtest"
+        android:title="@string/nav_drawer_speedtest_title"
         android:icon="@drawable/open_in_new_24px"
         android:checkableBehavior="none"/>
 </menu>

--- a/app/src/main/res/menu/nav_drawer.xml
+++ b/app/src/main/res/menu/nav_drawer.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:showIn="navigation_view">
+    <group android:id="@+id/group_pages">
     <item
         android:id="@+id/FirstFragment"
         android:title="@string/first_fragment_label" />
@@ -12,4 +12,10 @@
     <item
         android:id="@+id/DatenschutzPage"
         android:title="Datenschutz &amp; Impressum" />
+    </group>
+    <item
+        android:id="@+id/externalSpeedtest"
+        android:title="Externer Speedtest"
+        android:icon="@drawable/open_in_new_24px"
+        android:checkableBehavior="none"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,12 @@
     <string name="location_missing_dialog_settings">Einstellungen</string>
     <string name="refresh_message_missing_location">Bitte Standort aktivieren</string>
 
+    <string name="speedtest_URL">https://speed.cloudflare.com/</string>
+    <string name="speedtest_dialog_title">Externen Speedtest öffnen?</string>
+    <string name="speedtest_dialog_message">Du wirst zu einem externen Speedtest-Anbieter (Cloudflare) weitergeleitet. Dabei verlässt du Signalo und es gelten die Datenschutzbestimmungen von Cloudflare.</string>
+    <string name="speedtest_dialog_positive_button">Browser öffnen</string>
+    <string name="speedtest_dialog_negative_button">Abbrechen</string>
+    <string name="Speedtest_open_erorr">Kein Browser zum Öffnen des Speedtests gefunden</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="speedtest_dialog_positive_button">Browser öffnen</string>
     <string name="speedtest_dialog_negative_button">Abbrechen</string>
     <string name="Speedtest_open_erorr">Kein Browser zum Öffnen des Speedtests gefunden</string>
+    <string name="nav_drawer_speedtest_title">Externer Speedtest</string>
 
 
 </resources>


### PR DESCRIPTION
**Description**
Add new "Externer Speedtest" item to navDrawer
Add suitable icon
Open confirmation dialog with a privacy notice before leaving the app
Open Cloudflare Speedtest in the user's default browser (speed.cloudflare.com)

**Motivation**
A speedtest was a frequent feature request. Implementing an own speedtest service would require too much dedicated server infrastructure. That's why a redirect to an established external provider was implemented instead.